### PR TITLE
Feat/2: login and registration template

### DIFF
--- a/src/app/features/auth/login/login.component.html
+++ b/src/app/features/auth/login/login.component.html
@@ -26,3 +26,5 @@
 
   <button type="submit" [disabled]="loginForm.invalid">Login</button>
 </form>
+
+<span class="login-redirection">Don't you have an account? <a routerLink="/registration">Sign up</a></span>

--- a/src/app/features/auth/login/login.component.ts
+++ b/src/app/features/auth/login/login.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
 import ERROR_MSG from '../../../shared/constants/error-message';
 import { EMAIL_REGEX, PASSWORD_REGEX } from '../../../shared/constants/regex';
 import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-login',
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
   templateUrl: './login.component.html',
   styleUrl: '../registration/registration.component.scss',
 })

--- a/src/app/features/auth/registration/registration.component.html
+++ b/src/app/features/auth/registration/registration.component.html
@@ -113,3 +113,5 @@
 
   <button type="submit" [disabled]="registrationForm.invalid">Register</button>
 </form>
+
+<span class="login-redirection">Already have an account? <a routerLink="/login">Login</a></span>

--- a/src/app/features/auth/registration/registration.component.scss
+++ b/src/app/features/auth/registration/registration.component.scss
@@ -1,5 +1,8 @@
+@use '../../../../style/abstract/constant' as *;
+
 :host {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   height: 100vh;
@@ -58,4 +61,12 @@ input {
 .error-line {
   font-size: 1rem;
   color: indianred;
+}
+
+.login-redirection {
+  margin-top: 3.6rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 2px solid $color-primary;
+  background-color: $color-input-search;
 }

--- a/src/app/features/auth/registration/registration.component.ts
+++ b/src/app/features/auth/registration/registration.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { EMAIL_REGEX, NAME_REGEX, PASSWORD_REGEX } from '../../../shared/constants/regex';
 import ERROR_MSG from '../../../shared/constants/error-message';
@@ -9,7 +10,7 @@ import { postalCodeValidator } from '../../../shared/validator/validate.postal-c
 
 @Component({
   selector: 'app-registration',
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
   templateUrl: './registration.component.html',
   styleUrl: './registration.component.scss',
 })


### PR DESCRIPTION
## Cudo-Shop

### Sprint 2: [Login, Registration, and Main Pages Implementation](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%232.md)

#### 🟢 Navigation to Login and Registration Login (points +10/10)
- Link to Trello task: [Form template for Login and Registration page.](https://trello.com/c/ua7EVn9z/10-form-template-for-login-and-registration-page)

- Done 21.05.2025 / deadline 26.05.2025

---

##### 📝 This is a ...

- [x] New feature

##### 🔗 Related issue link

- [x] ☑️ **(5 points)** Add a button or link on the login page that allows users to navigate to the registration page. [RSS-ECOMM-2_08](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint2/RSS-ECOMM-2_08.md)
- [x] ☑️ **(5 points)** Add a button or link on the registration page that allows users to navigate to the login page. [RSS-ECOMM-2_16](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint2/RSS-ECOMM-2_16.md)

##### 💡 Background and solution

- RouterLink was used.  

##### ☑️ Self Check before Merge

###### Acceptance Criteria ✔️
- [x] A clear and prominent button or link is present on the login page to navigate to the registration page.
- [x] The button or link is functional and directs the user to the registration page.
- [x] Proper handling of navigation and user experience during this process.

###### Visual Implementation Ideas
- [x] Position the button or link strategically on the page so that it's easily noticeable. It could be placed below the registration form or near the top of the page for easy access. 🗺️
- [x] The button or link could say something like "Already have an account? Login". 💬
- [x] Use contrasting colors or fonts to make the button or link stand out. 🌈

###### Acceptance Criteria
- [x] The registration page includes a clear and visible button or link. 📌
- [x] Upon clicking the button or link, the user is redirected to the login page. 🔄