### PR TITLE
Add unit tests for authInterceptor and refreshTokenInterceptor.

### DIFF
--- a/src/app/core/interceptors/auth.interceptor.spec.ts
+++ b/src/app/core/interceptors/auth.interceptor.spec.ts
@@ -1,16 +1,47 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpInterceptorFn } from '@angular/common/http';
+import { HttpInterceptorFn, provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { authInterceptor } from './auth.interceptor';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { AuthService } from '../auth/auth.service';
 
 describe('authInterceptor', () => {
   const interceptor: HttpInterceptorFn = (req, next) => TestBed.runInInjectionContext(() => authInterceptor(req, next));
+  let authService: AuthService;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [AuthService, provideHttpClient(withInterceptors([authInterceptor])), provideHttpClientTesting()],
+    });
+    authService = TestBed.inject(AuthService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   it('should be created', () => {
     expect(interceptor).toBeTruthy();
+  });
+
+  it('should use authService', () => {
+    expect(authService).toBeTruthy();
+  });
+
+  describe('making http calls', () => {
+    it('should add Authorization header to the request', () => {
+      const url = '/api/test';
+      jest.spyOn(authService, 'login');
+      const mockUser = { email: 'test@example.com', password: '123qweQWE' };
+      authService.login(mockUser).subscribe((result) => {
+        expect(result).toBeTruthy();
+      });
+
+      const req = httpTestingController.expectOne(url);
+      expect(req.request.headers.get('Authorization')).toEqual('Basic mock_token');
+      req.flush('HTTP for testing purposes');
+    });
   });
 });

--- a/src/app/core/interceptors/refresh-token.interceptor.spec.ts
+++ b/src/app/core/interceptors/refresh-token.interceptor.spec.ts
@@ -1,16 +1,53 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpInterceptorFn } from '@angular/common/http';
+import { HttpInterceptorFn, provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { refreshTokenInterceptor } from './refresh-token.interceptor';
+import { AuthService } from '../auth/auth.service';
+import { StorageService } from '../auth/storage.service';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 
 describe('refreshTokenInterceptor', () => {
   const interceptor: HttpInterceptorFn = (req, next) => TestBed.runInInjectionContext(() => refreshTokenInterceptor(req, next));
+  let authService: AuthService;
+  let storageService: StorageService;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [AuthService, StorageService, provideHttpClient(withInterceptors([refreshTokenInterceptor])), provideHttpClientTesting()],
+    });
+    authService = TestBed.inject(AuthService);
+    storageService = TestBed.inject(StorageService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   it('should be created', () => {
     expect(interceptor).toBeTruthy();
+  });
+
+  it('should use authService', () => {
+    expect(authService).toBeTruthy();
+  });
+
+  it('should use storageService', () => {
+    expect(storageService).toBeTruthy();
+  });
+
+  describe('making http calls', () => {
+    it('should reset Authorization header to the request', () => {
+      const url = '/api/test';
+      jest.spyOn(authService, 'login');
+      authService.refreshToken().subscribe((result) => {
+        expect(result).toBeTruthy();
+      });
+
+      const req = httpTestingController.expectOne(url);
+      expect(req.request.headers.get('Authorization')).toEqual('Bearer mock_token');
+      req.flush('HTTP for testing purposes');
+    });
   });
 });


### PR DESCRIPTION
## Cudo-Shop

### Sprint 2: [Login, Registration, and Main Pages Implementation](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%232.md)

#### 🟢 Unit tests
- Tests for Interceptors.
- Test authInterceptor to add the authorization header to the request.
- Test refreshTokenInterceptor to reset the authorization header in the request.

![image](https://firebasestorage.googleapis.com/v0/b/personal-portfolio-b7e69.appspot.com/o/RS-School-JavaScript-course-2024%2FFinal-task%2Ftests-interceptors.png?alt=media&token=2baac007-a545-4905-b59c-d28f36751ab3)

- Done 29.05.2025 / deadline 26.05.2025

---

##### 📝 This is a ...

- [x] Test Case

##### 🔗 Related issue link

- [x] - 🧪 **Unit Test Coverage (15 points):** The codebase has a minimum of 25% unit test coverage, ensuring the reliability and robustness of the implemented features.