### PR TITLE
Feat/3 19/navigation catalog product detail

### DIFF
--- a/src/app/core/product/interfaces/product.ts
+++ b/src/app/core/product/interfaces/product.ts
@@ -8,4 +8,5 @@ export interface Product {
     current: ProductMasterData;
     staged: ProductMasterData;
   };
+  key: string;
 }

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.ts
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.ts
@@ -11,23 +11,25 @@ import { ButtonComponent } from '../../../shared/ui/button/button.component';
 })
 export class ProductDetailedInfoComponent implements OnInit {
   @Input() public product: ProductDetailed | null = null;
+  @Input() public key: string | null = null;
   public products: ProductDetailed[] = [];
 
   constructor(private productDetailedService: ProductDetailedService) {}
 
   public ngOnInit(): void {
-    const key = '101221075';
-    this.productDetailedService.getProductByKey(key).subscribe({
-      next: (product: ProductDetailed) => {
-        const responseStr = JSON.stringify(product);
-        const productResponse: ProductDetailed = JSON.parse(responseStr);
-        this.products[0] = productResponse;
-        console.log('product', this.products[0]);
-      },
-      error: (error) => {
-        console.error(`Loading error: ${error}`);
-      },
-    });
+    if (this.key) {
+      this.productDetailedService.getProductByKey(this.key).subscribe({
+        next: (product: ProductDetailed) => {
+          const responseStr = JSON.stringify(product);
+          const productResponse: ProductDetailed = JSON.parse(responseStr);
+          this.products[0] = productResponse;
+          console.log('product', this.products[0]);
+        },
+        error: (error) => {
+          console.error(`Loading error: ${error}`);
+        },
+      });
+    }
   }
 
   public getProductImage(product: ProductDetailed): string {

--- a/src/app/features/product/product-list/product-list.component.html
+++ b/src/app/features/product/product-list/product-list.component.html
@@ -12,10 +12,12 @@
 
 <div class="product-list">
   @for (product of products; track $index) {
-    <app-brief-card
-      [title]="getProductName(product)"
-      [imgUrl]="getProductImg(product)"
-      [description]="getShortProductDescription(product)"
-    ></app-brief-card>
+    <div [routerLink]="['/books/', product.id]" class="product-list__item-link">
+      <app-brief-card
+        [title]="getProductName(product)"
+        [imgUrl]="getProductImg(product)"
+        [description]="getShortProductDescription(product)"
+      ></app-brief-card>
+    </div>
   }
 </div>

--- a/src/app/features/product/product-list/product-list.component.html
+++ b/src/app/features/product/product-list/product-list.component.html
@@ -12,12 +12,14 @@
 
 <div class="product-list">
   @for (product of products; track $index) {
-    <div [routerLink]="['/books/', product.id]" class="product-list__item-link">
-      <app-brief-card
-        [title]="getProductName(product)"
-        [imgUrl]="getProductImg(product)"
-        [description]="getShortProductDescription(product)"
-      ></app-brief-card>
-    </div>
+    @if (product.key) {
+      <div [routerLink]="['/books', product.key]" class="product-list__item-link">
+        <app-brief-card
+          [title]="getProductName(product)"
+          [imgUrl]="getProductImg(product)"
+          [description]="getShortProductDescription(product)"
+        ></app-brief-card>
+      </div>
+    }
   }
 </div>

--- a/src/app/features/product/product-list/product-list.component.scss
+++ b/src/app/features/product/product-list/product-list.component.scss
@@ -2,4 +2,8 @@
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
+
+  &__item-link {
+    cursor: pointer;
+  }
 }

--- a/src/app/features/product/product-list/product-list.component.ts
+++ b/src/app/features/product/product-list/product-list.component.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 
 import { BriefCardComponent } from './brief-card/brief-card.component';
 import { Product } from '../../../core/product/interfaces/product';
@@ -10,7 +10,7 @@ import { NavigateToSpecificRouteService } from '../../../shared/services/navigat
 
 @Component({
   selector: 'app-product-list',
-  imports: [BriefCardComponent],
+  imports: [BriefCardComponent, RouterLink],
   templateUrl: './product-list.component.html',
   styleUrl: './product-list.component.scss',
 })

--- a/src/app/features/product/product.routes.ts
+++ b/src/app/features/product/product.routes.ts
@@ -8,7 +8,7 @@ export const productRoutes: Routes = [
     component: ProductListComponent,
   },
   {
-    path: ':id',
+    path: ':key',
     component: ProductDetailedInfoComponent,
   },
 ];


### PR DESCRIPTION
## Cudo-Shop

### [Sprint 3 - Catalog Product, Detailed Product, and User Profile Pages Implementation](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%233.md) 📚🔍👥

#### 🟢 Routing Implementation (+ 25 / 40 points - Total) 🛣️

3. Done 01.06.2025 / deadline 09.06.2025

---

##### 📝 This is a ...

- [x] New feature

##### 🔗 Related issue link

- [x] (+25 / 25 points) Implement routing for navigation between Catalog page, Product detail page. [RSS-ECOMM-3_19](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint3/RSS-ECOMM-3_19.md) 🚦

##### ☑️ Self Check before Merge

⚠️ _Please check all items below before review_ ⚠️

- [x] - Clicking on a product card from the Catalog page takes the user to the corresponding Product Detail page.
- [x] - Navigating from the Catalog page to a Product Detail page and vice versa changes the URL in the browser.
- [x] - Each product has a unique URL that can be directly accessed to view its details.
- [x] - Directly accessing a product's unique URL leads to the corresponding Product Detail page.
- [x] - The browser's back and forward buttons work as expected, enabling the user to navigate through their history of visited pages.
- [x] - The Catalog and Product Detail pages are accessible regardless of the user's authentication state.