### PR TITLE
Feat/3-10/slider for product images

### DIFF
--- a/src/app/core/product/interfaces/product-image.ts
+++ b/src/app/core/product/interfaces/product-image.ts
@@ -1,7 +1,4 @@
 export interface ProductImage {
+  label: string;
   url: string;
-  dimensions: {
-    w: string;
-    h: string;
-  };
 }

--- a/src/app/features/product/product-detailed-info/interfaces/product-detailed.ts
+++ b/src/app/features/product/product-detailed-info/interfaces/product-detailed.ts
@@ -1,41 +1,39 @@
+import { ProductImage } from '../../../../core/product/interfaces/product-image';
+
 export interface ProductDetailed {
   id: string;
   key: string;
   masterData: {
     current: {
       name: {
-        'en-US': string,
-      },
+        'en-US': string;
+      };
       categories: {
-        typeId: string,
-        id: string,
-      },
+        typeId: string;
+        id: string;
+      };
       description: {
-        'en-US': string,
-      },
+        'en-US': string;
+      };
       masterVariant: {
-        sku: string | number,
-        key: string | number,
-        images: [
-          {
-            url: string,
-          },
-        ],
+        sku: string | number;
+        key: string | number;
+        images: ProductImage[];
         prices: [
           {
             discounted: {
               value: {
-                currencyCode: string,
-                centAmount: number,
-              }
-            },
+                currencyCode: string;
+                centAmount: number;
+              };
+            };
             value: {
-              centAmount: number,
-              currencyCode: string,
-            }
+              centAmount: number;
+              currencyCode: string;
+            };
           },
-        ],
-      },
-    },
+        ];
+      };
+    };
   };
 }

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.html
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.html
@@ -19,5 +19,10 @@
         <p class="product-description">{{ getProductDescription(product) }}</p>
       </div>
     </div>
+    <div class="image__container">
+      <div *ngFor="let image of getProductImages(product)">
+        <img [src]="image.url" alt="picture" />
+      </div>
+    </div>
   }
 </div>

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.html
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.html
@@ -2,7 +2,12 @@
   @for (product of products; track product.id) {
     <div class="product__wrapper">
       <div class="product-image">
-        <img [src]="getProductImage(product)" alt="picture" />
+        <!--<img [src]="getProductImage(product)" alt="picture" />-->
+        <app-button label="<" (buttonClicked)="onClickLeft()" class="image__button" />
+        <div *ngIf="getCurrentImage() as currentImage">
+          <img [src]="currentImage.url" [alt]="currentImage.label" />
+        </div>
+        <app-button label=">" (buttonClicked)="onClickRight()" class="image__button" />
       </div>
       <div class="product-information">
         <h2 class="product-title">{{ getProductName(product) }}</h2>
@@ -17,11 +22,6 @@
         </div>
         <app-button label="Add to cart" (buttonClicked)="buttonClickedAddToCart.emit()" class="product__button" />
         <p class="product-description">{{ getProductDescription(product) }}</p>
-      </div>
-    </div>
-    <div class="image__container">
-      <div *ngFor="let image of getProductImages(product)">
-        <img [src]="image.url" alt="picture" />
       </div>
     </div>
   }

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.scss
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.scss
@@ -5,9 +5,9 @@
 .product__wrapper {
   display: flex;
   justify-content: space-evenly;
-  padding: 7rem 10rem;
+  padding: 7rem 3rem;
   @include media-laptop-tablet {
-    padding: 7rem 5rem;
+    column-gap: 2rem;
   }
   @include media-tablet {
     padding: 5rem;
@@ -23,6 +23,8 @@
   width: 30%;
   height: fit-content;
   text-align: center;
+  align-items: center;
+  display: flex;
   @include media-laptop-tablet {
     width: 50%;
   }
@@ -32,18 +34,23 @@
   }
 }
 
-/*.image__container {
-  display: flex;
-}*/
+.image__button{
+  background-color: $color-input-search;
+  cursor: pointer;
+  color: $color-primary;
+  font-weight: bold;
+  font-size: 3.6rem;
+  @extend %transition;
+  &:hover{
+    background-color: $color-button-disable;
+  }
+}
 
 .product-image img {
-  width: 80%;
+  width: 100%;
   height: 70%;
   @include media-laptop-tablet {
-    width: 80%;
-  }
-  @include media-tablet {
-    width: 60%;
+    width: 90%;
   }
   @include media-mobile-big {
     width: 50%;
@@ -136,8 +143,4 @@
   @include media-tablet {
     font-size: 1.4rem;
   }
-}
-
-.image__container {
-  display: flex;
 }

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.scss
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.scss
@@ -32,6 +32,10 @@
   }
 }
 
+/*.image__container {
+  display: flex;
+}*/
+
 .product-image img {
   width: 80%;
   height: 70%;
@@ -132,4 +136,8 @@
   @include media-tablet {
     font-size: 1.4rem;
   }
+}
+
+.image__container {
+  display: flex;
 }

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.ts
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.ts
@@ -16,6 +16,7 @@ export class ProductDetailedInfoComponent implements OnInit {
   @Input() public key: string | null = null;
   public products: ProductDetailed[] = [];
   public productImages: ProductImage[] = [];
+  public currentImageIndex: number = 0;
 
   constructor(private productDetailedService: ProductDetailedService) {}
 
@@ -26,6 +27,8 @@ export class ProductDetailedInfoComponent implements OnInit {
           const responseStr = JSON.stringify(product);
           const productResponse: ProductDetailed = JSON.parse(responseStr);
           this.products[0] = productResponse;
+          this.getProductImages(productResponse);
+          this.currentImageIndex = 0;
         },
         error: (error) => {
           console.error(`Loading error: ${error}`);
@@ -89,5 +92,25 @@ export class ProductDetailedInfoComponent implements OnInit {
     console.log('productImages', this.productImages);
 
     return this.productImages;
+  }
+
+  public onClickLeft() {
+    if (this.productImages.length > 0) {
+      this.currentImageIndex = (this.currentImageIndex - 1 + this.productImages.length) % this.productImages.length;
+    }
+  }
+
+  public onClickRight() {
+    if (this.productImages.length > 0) {
+      this.currentImageIndex = (this.currentImageIndex + 1) % this.productImages.length;
+    }
+  }
+
+  public getCurrentImage(): ProductImage | null {
+    if (this.productImages.length > 0 && this.currentImageIndex >= 0 && this.currentImageIndex < this.productImages.length) {
+      return this.productImages[this.currentImageIndex];
+    }
+
+    return null;
   }
 }

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.ts
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.ts
@@ -3,6 +3,7 @@ import { ProductDetailed } from './interfaces/product-detailed';
 import { ProductDetailedService } from './services/product-detailed.service';
 import { ButtonComponent } from '../../../shared/ui/button/button.component';
 import { CommonModule } from '@angular/common';
+import { ProductImage } from '../../../core/product/interfaces/product-image';
 
 @Component({
   selector: 'app-product-detailed-info',
@@ -14,6 +15,7 @@ export class ProductDetailedInfoComponent implements OnInit {
   @Input() public product: ProductDetailed | null = null;
   @Input() public key: string | null = null;
   public products: ProductDetailed[] = [];
+  public productImages: ProductImage[] = [];
 
   constructor(private productDetailedService: ProductDetailedService) {}
 
@@ -80,5 +82,12 @@ export class ProductDetailedInfoComponent implements OnInit {
     const productDescription = product.masterData.current.description['en-US'];
 
     return productDescription;
+  }
+
+  public getProductImages(product: ProductDetailed): ProductImage[] {
+    this.productImages = product.masterData.current.masterVariant.images;
+    console.log('productImages', this.productImages);
+
+    return this.productImages;
   }
 }


### PR DESCRIPTION
## Cudo-Shop

### [Sprint 3: Catalog Product Page, Detailed Product Page & User Profile Page Implementation](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%233.md)

#### 🟢 Implement an Image Slider for Product Images  (+25/25 points) 📋

1. Screenshot:
![image](https://github.com/user-attachments/assets/5246b8ba-7cca-4f92-a34e-1ec202bcbac1)



2. Done 03.06.2025 / deadline 09.06.2025

---

##### 📝 This is a ...

- [x] New feature

#####  Changed files:
 - src/app/core/product/interfaces/product-image.ts
- src/app/features/product/product-detailed-info/interfaces/product-detailed.ts
- src/app/features/product/product-detailed-info/product-detailed-info.component.html
- src/app/features/product/product-detailed-info/product-detailed-info.component.scss
- src/app/features/product/product-detailed-info/product-detailed-info.component.ts

##### 🔗 Related issue link

- [x] (+25 / 25 points) Implement an image slider for product images fetched from the chosen API, allowing users to view multiple images of the product. [RSS-ECOMM-3_10](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint3/RSS-ECOMM-3_10.md) 📄

##### ☑️ Self Check before Merge

⚠️ _Please check all items below before review_ ⚠️

- [x] - The application successfully fetches multiple images for a product from the chosen API, when available..
- [x] - An image slider is implemented on the Detailed Product page, and can handle multiple images. The slider allows users to manually control which image is displayed.
- [x] - The image slider should be interactive, letting users control which image is currently displayed.