### PR TITLE
Feat/3-12/enlarged image modal with slider

### DIFF
--- a/src/app/features/product/product-detailed-info/modal/modal/modal.component.html
+++ b/src/app/features/product/product-detailed-info/modal/modal/modal.component.html
@@ -3,8 +3,8 @@
     <app-button label="X" (buttonClicked)="closeModal()" class="modal__button" />
     <div class="modal__window">
       <app-button label="<" (buttonClicked)="onClickLeft()" class="modal__left" />
-      <div class="modal__image-container">
-        <img [src]="src" [alt]="alt" />
+      <div *ngIf="getCurrentImage() as currentImage" class="modal__image-container">
+        <img [src]="currentImage.url" [alt]="currentImage.label" />
       </div>
       <app-button label=">" (buttonClicked)="onClickRight()" class="modal__right" />
     </div>

--- a/src/app/features/product/product-detailed-info/modal/modal/modal.component.html
+++ b/src/app/features/product/product-detailed-info/modal/modal/modal.component.html
@@ -1,0 +1,11 @@
+<p>modal works!</p>
+<div class="modal__wrapper" *ngIf="isModalOpen">
+  <div class="modal">
+    <app-button label="X" (buttonClicked)="closeModal()" class="modal__button" />
+    <div class="modal__window">
+      <app-button label="<" (buttonClicked)="onClickLeft()" class="modal__left" />
+      <img [src]="" alt="" />
+      <app-button label=">" (buttonClicked)="onClickRight()" class="modal__right" />
+    </div>
+  </div>
+</div>

--- a/src/app/features/product/product-detailed-info/modal/modal/modal.component.html
+++ b/src/app/features/product/product-detailed-info/modal/modal/modal.component.html
@@ -1,10 +1,11 @@
-<p>modal works!</p>
 <div class="modal__wrapper" *ngIf="isModalOpen">
   <div class="modal">
     <app-button label="X" (buttonClicked)="closeModal()" class="modal__button" />
     <div class="modal__window">
       <app-button label="<" (buttonClicked)="onClickLeft()" class="modal__left" />
-      <img [src]="" alt="" />
+      <div class="modal__image-container">
+        <img [src]="src" [alt]="alt" />
+      </div>
       <app-button label=">" (buttonClicked)="onClickRight()" class="modal__right" />
     </div>
   </div>

--- a/src/app/features/product/product-detailed-info/modal/modal/modal.component.scss
+++ b/src/app/features/product/product-detailed-info/modal/modal/modal.component.scss
@@ -8,7 +8,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: $color-overlay;
+  background-color: $color-button-disable;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -17,19 +17,29 @@
 .modal {
   position: relative;
   margin: 0 auto;
-  width: 80%;
+  width: 100%;
+  height: 100%;
+  align-content: center;
+  padding: 1rem;
+  @include media-tablet {
+    padding: 0.5rem;
+  }
 }
 
 .modal__button {
   position: absolute;
-  top: 0;
-  right: 11px;
+  top: 1rem;
+  right: 1rem;
+  align-self: flex-end;
   font-size: 3.6rem;
   color: $color-input-search;
   cursor: pointer;
   @extend %transition;
   &:hover {
     color: $color-primary;
+  }
+  @include media-mobile-big {
+    font-size: 2.4rem;
   }
 }
 
@@ -40,13 +50,25 @@
 }
 
 .modal__image-container {
-  height: 60%;
+  height: 80%;
 }
 
 .modal__image-container img {
-  width: 80%;
-  height: 70%;
-  object-fit: cover;
+  height: 70rem;
+  width: 50rem;
+  object-fit: contain;
+  @include media-tablet {
+    height: 60rem;
+    width: 40rem;
+  }
+  @include media-mobile-big {
+    height: 50rem;
+    width: 30rem;
+   }
+  @include media-mobile {
+    height: 40rem;
+    width: 20rem;
+   }
 }
 
 .modal__left,

--- a/src/app/features/product/product-detailed-info/modal/modal/modal.component.scss
+++ b/src/app/features/product/product-detailed-info/modal/modal/modal.component.scss
@@ -1,0 +1,33 @@
+@use '../../../../../../style/abstract/constant' as *;
+@use '../../../../../../style/abstract/mixins' as *;
+@use '../../../../../../style/abstract/placeholders' as *;
+
+.modal__wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: $color-overlay;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  position: relative;
+  margin: 0 auto;
+}
+
+.modal__button {
+  position: absolute;
+  top: 0;
+  right: 11px;
+  font-size: 3.6rem;
+  color: $color-input-search;
+  cursor: pointer;
+  @extend %transition;
+  &:hover {
+    color: $color-primary;
+  }
+}

--- a/src/app/features/product/product-detailed-info/modal/modal/modal.component.scss
+++ b/src/app/features/product/product-detailed-info/modal/modal/modal.component.scss
@@ -17,6 +17,7 @@
 .modal {
   position: relative;
   margin: 0 auto;
+  width: 80%;
 }
 
 .modal__button {
@@ -25,6 +26,34 @@
   right: 11px;
   font-size: 3.6rem;
   color: $color-input-search;
+  cursor: pointer;
+  @extend %transition;
+  &:hover {
+    color: $color-primary;
+  }
+}
+
+.modal__window {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.modal__image-container {
+  height: 60%;
+}
+
+.modal__image-container img {
+  width: 80%;
+  height: 70%;
+  object-fit: cover;
+}
+
+.modal__left,
+.modal__right {
+  font-size: 3.6rem;
+  color: $color-input-search;
+  background-color: $color-button-disable;
   cursor: pointer;
   @extend %transition;
   &:hover {

--- a/src/app/features/product/product-detailed-info/modal/modal/modal.component.spec.ts
+++ b/src/app/features/product/product-detailed-info/modal/modal/modal.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ModalComponent } from './modal.component';
+
+describe('ModalComponent', () => {
+  let component: ModalComponent;
+  let fixture: ComponentFixture<ModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ModalComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/product/product-detailed-info/modal/modal/modal.component.ts
+++ b/src/app/features/product/product-detailed-info/modal/modal/modal.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-modal',
+  imports: [],
+  templateUrl: './modal.component.html',
+  styleUrl: './modal.component.scss'
+})
+export class ModalComponent {
+  public isModalOpen: boolean = false;
+
+  public openModal(): void {
+    this.isModalOpen = true;
+  }
+
+  public closeModal(): void {
+    this.isModalOpen = false;
+  }
+}

--- a/src/app/features/product/product-detailed-info/modal/modal/modal.component.ts
+++ b/src/app/features/product/product-detailed-info/modal/modal/modal.component.ts
@@ -1,19 +1,33 @@
-import { Component } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ButtonComponent } from '../../../../../shared/ui/button/button.component';
+//import { ProductImage } from '../../../../../core/product/interfaces/product-image';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-modal',
-  imports: [],
+  imports: [CommonModule, ButtonComponent],
   templateUrl: './modal.component.html',
-  styleUrl: './modal.component.scss'
+  styleUrl: './modal.component.scss',
 })
 export class ModalComponent {
-  public isModalOpen: boolean = false;
+  @Input() public isModalOpen: boolean = false;
+  //@Input() public images: ProductImage[] = [];
+  @Input() public currentIndex: number = 0;
+  @Input() public src: string = '';
+  @Input() public alt: string = '';
 
-  public openModal(): void {
+  @Output() public closeModalWindow = new EventEmitter<void>();
+
+  public openModal(index: number): void {
     this.isModalOpen = true;
+    this.currentIndex = index;
   }
 
   public closeModal(): void {
     this.isModalOpen = false;
+    this.closeModalWindow.emit();
   }
+
+  public onClickLeft() {}
+  public onClickRight() {}
 }

--- a/src/app/features/product/product-detailed-info/modal/modal/modal.component.ts
+++ b/src/app/features/product/product-detailed-info/modal/modal/modal.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ButtonComponent } from '../../../../../shared/ui/button/button.component';
-//import { ProductImage } from '../../../../../core/product/interfaces/product-image';
+import { ProductImage } from '../../../../../core/product/interfaces/product-image';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -11,23 +11,39 @@ import { CommonModule } from '@angular/common';
 })
 export class ModalComponent {
   @Input() public isModalOpen: boolean = false;
-  //@Input() public images: ProductImage[] = [];
+  @Input() public images: ProductImage[] = [];
   @Input() public currentIndex: number = 0;
   @Input() public src: string = '';
   @Input() public alt: string = '';
 
-  @Output() public closeModalWindow = new EventEmitter<void>();
+  @Output() public closeModalWindow = new EventEmitter<number>();
 
   public openModal(index: number): void {
     this.isModalOpen = true;
     this.currentIndex = index;
   }
 
-  public closeModal(): void {
-    this.isModalOpen = false;
-    this.closeModalWindow.emit();
+  public onClickLeft() {
+    if (this.images.length > 0) {
+      this.currentIndex = (this.currentIndex - 1 + this.images.length) % this.images.length;
+    }
+  }
+  public onClickRight() {
+    if (this.images.length > 0) {
+      this.currentIndex = (this.currentIndex + 1) % this.images.length;
+    }
   }
 
-  public onClickLeft() {}
-  public onClickRight() {}
+  public getCurrentImage(): ProductImage | null {
+    if (this.images.length > 0 && this.currentIndex >= 0 && this.currentIndex <= this.images.length) {
+      return this.images[this.currentIndex];
+    }
+
+    return null;
+  }
+
+  public closeModal(): void {
+    this.closeModalWindow.emit(this.currentIndex);
+
+  }
 }

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.html
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.html
@@ -5,7 +5,14 @@
         <!--<img [src]="getProductImage(product)" alt="picture" />-->
         <app-button label="<" (buttonClicked)="onClickLeft()" class="image__button" />
         <div *ngIf="getCurrentImage() as currentImage">
-          <img [src]="currentImage.url" [alt]="currentImage.label" />
+          <img [src]="currentImage.url" [alt]="currentImage.label" (click)="openImageInModal()" />
+          <app-modal
+            [isModalOpen]="isModalOpen"
+            [src]="currentImage.url"
+            [alt]="currentImage.label"
+            [currentIndex]="modalStartIndex"
+            (closeModalWindow)="isModalOpen = false"
+          ></app-modal>
         </div>
         <app-button label=">" (buttonClicked)="onClickRight()" class="image__button" />
       </div>

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.html
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.html
@@ -2,16 +2,16 @@
   @for (product of products; track product.id) {
     <div class="product__wrapper">
       <div class="product-image">
-        <!--<img [src]="getProductImage(product)" alt="picture" />-->
         <app-button label="<" (buttonClicked)="onClickLeft()" class="image__button" />
         <div *ngIf="getCurrentImage() as currentImage">
           <img [src]="currentImage.url" [alt]="currentImage.label" (click)="openImageInModal()" />
           <app-modal
             [isModalOpen]="isModalOpen"
+            [images]="productImages"
             [src]="currentImage.url"
             [alt]="currentImage.label"
-            [currentIndex]="modalStartIndex"
-            (closeModalWindow)="isModalOpen = false"
+            [currentIndex]="currentImageIndex"
+            (closeModalWindow)="onCloseModal($event)"
           ></app-modal>
         </div>
         <app-button label=">" (buttonClicked)="onClickRight()" class="image__button" />

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.spec.ts
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { routes } from '../../../app.routes';
 
 import { ProductDetailedInfoComponent } from './product-detailed-info.component';
 
@@ -9,6 +13,7 @@ describe('ProductDetailedInfoComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProductDetailedInfoComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter(routes)]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ProductDetailedInfoComponent);

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.ts
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.ts
@@ -15,11 +15,13 @@ import { ModalComponent } from './modal/modal/modal.component';
 export class ProductDetailedInfoComponent implements OnInit {
   @Input() public product: ProductDetailed | null = null;
   @Input() public key: string | null = null;
+  @Input() public currentImageIndex: number = 0;
+  
+  @Output() public buttonClickedAddToCart = new EventEmitter();
+
   public products: ProductDetailed[] = [];
   public productImages: ProductImage[] = [];
-  public currentImageIndex: number = 0;
   public isModalOpen: boolean = false;
-  public modalStartIndex: number = 0;
 
   constructor(private productDetailedService: ProductDetailedService) {}
 
@@ -39,12 +41,6 @@ export class ProductDetailedInfoComponent implements OnInit {
       });
     }
   }
-
-  // public getProductImage(product: ProductDetailed): string {
-  //   const productImage = product.masterData.current.masterVariant.images[0].url;
-
-  //   return productImage;
-  // }
 
   public getProductName(product: ProductDetailed): string {
     const productName = product.masterData.current.name['en-US'];
@@ -82,8 +78,6 @@ export class ProductDetailedInfoComponent implements OnInit {
     return productCurrency;
   }
 
-  @Output() public buttonClickedAddToCart = new EventEmitter();
-
   public getProductDescription(product: ProductDetailed): string {
     const productDescription = product.masterData.current.description['en-US'];
 
@@ -92,7 +86,6 @@ export class ProductDetailedInfoComponent implements OnInit {
 
   public getProductImages(product: ProductDetailed): ProductImage[] {
     this.productImages = product.masterData.current.masterVariant.images;
-    console.log('productImages', this.productImages);
 
     return this.productImages;
   }
@@ -121,10 +114,8 @@ export class ProductDetailedInfoComponent implements OnInit {
     this.isModalOpen = true;
   }
 
-  // public onKeydown(event: KeyboardEvent): void {
-  //   if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
-  //     event.preventDefault();
-  //     this.openImageInModal();
-  //   }
-  // }
+  public onCloseModal(index: number): void {
+    this.currentImageIndex = index;
+    this.isModalOpen = false;
+  }
 }

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.ts
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.ts
@@ -4,10 +4,11 @@ import { ProductDetailedService } from './services/product-detailed.service';
 import { ButtonComponent } from '../../../shared/ui/button/button.component';
 import { CommonModule } from '@angular/common';
 import { ProductImage } from '../../../core/product/interfaces/product-image';
+import { ModalComponent } from './modal/modal/modal.component';
 
 @Component({
   selector: 'app-product-detailed-info',
-  imports: [ButtonComponent, CommonModule],
+  imports: [ButtonComponent, CommonModule, ModalComponent],
   templateUrl: './product-detailed-info.component.html',
   styleUrl: './product-detailed-info.component.scss',
 })
@@ -17,6 +18,8 @@ export class ProductDetailedInfoComponent implements OnInit {
   public products: ProductDetailed[] = [];
   public productImages: ProductImage[] = [];
   public currentImageIndex: number = 0;
+  public isModalOpen: boolean = false;
+  public modalStartIndex: number = 0;
 
   constructor(private productDetailedService: ProductDetailedService) {}
 
@@ -37,11 +40,11 @@ export class ProductDetailedInfoComponent implements OnInit {
     }
   }
 
-  public getProductImage(product: ProductDetailed): string {
-    const productImage = product.masterData.current.masterVariant.images[0].url;
+  // public getProductImage(product: ProductDetailed): string {
+  //   const productImage = product.masterData.current.masterVariant.images[0].url;
 
-    return productImage;
-  }
+  //   return productImage;
+  // }
 
   public getProductName(product: ProductDetailed): string {
     const productName = product.masterData.current.name['en-US'];
@@ -113,4 +116,15 @@ export class ProductDetailedInfoComponent implements OnInit {
 
     return null;
   }
+
+  public openImageInModal(): void {
+    this.isModalOpen = true;
+  }
+
+  // public onKeydown(event: KeyboardEvent): void {
+  //   if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+  //     event.preventDefault();
+  //     this.openImageInModal();
+  //   }
+  // }
 }

--- a/src/style/abstract/_constant.scss
+++ b/src/style/abstract/_constant.scss
@@ -13,5 +13,5 @@ $color-input-search: #eee;
 $content-width: 1440px;
 $tablet-width: 768px;
 $mobile-width: 380px;
-$mobile-big-width: 440px;
+$mobile-big-width: 460px;
 $laptop-tablet-width: 894px;


### PR DESCRIPTION
## Cudo-Shop

### [Sprint 3: Catalog Product Page, Detailed Product Page & User Profile Page Implementation](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%233.md)

#### 🟢 Enlarged Image Modal with Slider (+35/35 points) 📋

1. Screenshot:
![image](https://github.com/user-attachments/assets/a1176af3-dcc1-4b6f-aa60-87685b73deda)

2. Done 05.06.2025 / deadline 09.06.2025

---

##### 📝 This is a ...

- [x] New feature

#####  Changed files:
- src/app/features/product/product-detailed-info/modal/modal/modal.component.html;
 - src/app/features/product/product-detailed-info/modal/modal/modal.component.scss;
 - src/app/features/product/product-detailed-info/modal/modal/modal.component.spec.ts;
 - src/app/features/product/product-detailed-info/modal/modal/modal.component.ts;
 - src/app/features/product/product-detailed-info/product-detailed-info.component.html;
 - src/app/features/product/product-detailed-info/product-detailed-info.component.spec.ts;
 - src/app/features/product/product-detailed-info/product-detailed-info.component.ts;
 - src/style/abstract/_constant.scss; 


##### 🔗 Related issue link

- [x] (+20 / 20 points) Allow users to click on the product image to open an enlarged version of the image in a modal window. [RSS-ECOMM-3_12](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint3/RSS-ECOMM-3_12.md) 📄
- [x] (+15 / 15 points) Enable users to navigate through all product images from the commercetools API using a slider inside the modal window [RSS-ECOMM-3_13](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint3/RSS-ECOMM-3_13.md)

##### ☑️ Self Check before Merge

⚠️ _Please check all items below before review_ ⚠️

- [x] - Implement a modal window that can display an enlarged version of a product image.
- [x] - Attach an event listener to the product image that triggers the modal to open with the enlarged image when the image is clicked.
- [x] - The enlarged image in the modal is significantly larger than the product image.
- [x] - When the modal opens, darken or blur the rest of the page behind the modal to help it stand out.
- [x] - The close button is easily visible and clearly indicates its purpose
- [x] - The enlarged image modal includes a slider that displays all product images fetched from the API.
- [x] - Users can navigate through the images using the slider controls.