### PR TITLE
Bugfix/product details layout

### DIFF
--- a/src/app/assets/icons/arrow_back.svg
+++ b/src/app/assets/icons/arrow_back.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#000000"><path d="M400-80 0-480l400-400 71 71-329 329 329 329-71 71Z"/></svg>

--- a/src/app/assets/icons/arrow_back_hover.svg
+++ b/src/app/assets/icons/arrow_back_hover.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#f07800"><path d="M400-80 0-480l400-400 71 71-329 329 329 329-71 71Z"/></svg>

--- a/src/app/assets/icons/arrow_forward.svg
+++ b/src/app/assets/icons/arrow_forward.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#000000"><path d="m321-80-71-71 329-329-329-329 71-71 400 400L321-80Z"/></svg>

--- a/src/app/assets/icons/arrow_forward_hover.svg
+++ b/src/app/assets/icons/arrow_forward_hover.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#f07800"><path d="m321-80-71-71 329-329-329-329 71-71 400 400L321-80Z"/></svg>

--- a/src/app/features/product/product-detailed-info/modal/modal/modal.component.html
+++ b/src/app/features/product/product-detailed-info/modal/modal/modal.component.html
@@ -1,12 +1,18 @@
 <div class="modal__wrapper" *ngIf="isModalOpen">
   <div class="modal">
-    <app-button label="X" (buttonClicked)="closeModal()" class="modal__button" />
+    <app-button (buttonClicked)="closeModal()" class="modal__button">
+      <div class="modal__close"></div>
+    </app-button>
     <div class="modal__window">
-      <app-button label="<" (buttonClicked)="onClickLeft()" class="modal__left" />
+      <app-button (buttonClicked)="onClickLeft()" class="modal__left">
+        <div class="arrow arrow__left"></div>
+      </app-button>
       <div *ngIf="getCurrentImage() as currentImage" class="modal__image-container">
         <img [src]="currentImage.url" [alt]="currentImage.label" />
       </div>
-      <app-button label=">" (buttonClicked)="onClickRight()" class="modal__right" />
+      <app-button (buttonClicked)="onClickRight()" class="modal__right">
+        <div class="arrow arrow__right"></div>
+      </app-button>
     </div>
   </div>
 </div>

--- a/src/app/features/product/product-detailed-info/modal/modal/modal.component.scss
+++ b/src/app/features/product/product-detailed-info/modal/modal/modal.component.scss
@@ -32,14 +32,18 @@
   right: 1rem;
   align-self: flex-end;
   font-size: 3.6rem;
-  color: $color-input-search;
   cursor: pointer;
+}
+
+.modal__close {
+  width: 30px;
+  height: 30px;
   @extend %transition;
+  background-position: center;
+  background-image: url('../../../../../assets/icons/close_24dp.svg');
+
   &:hover {
-    color: $color-primary;
-  }
-  @include media-mobile-big {
-    font-size: 2.4rem;
+    background-image: url('../../../../../assets/icons/close_24dp_color.svg');
   }
 }
 
@@ -64,21 +68,34 @@
   @include media-mobile-big {
     height: 50rem;
     width: 30rem;
-   }
+  }
   @include media-mobile {
     height: 40rem;
     width: 20rem;
-   }
+  }
 }
 
 .modal__left,
 .modal__right {
-  font-size: 3.6rem;
-  color: $color-input-search;
-  background-color: $color-button-disable;
   cursor: pointer;
+}
+
+.arrow {
+  width: 24px;
+  height: 24px;
   @extend %transition;
-  &:hover {
-    color: $color-primary;
+  &__left {
+    background-image: url('../../../../../assets/icons/arrow_back.svg');
+
+    &:hover {
+      background-image: url('../../../../../assets/icons/arrow_back_hover.svg');
+    }
+  }
+  &__right {
+    background-image: url('../../../../../assets/icons/arrow_forward.svg');
+
+    &:hover {
+      background-image: url('../../../../../assets/icons/arrow_forward_hover.svg');
+    }
   }
 }

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.html
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.html
@@ -4,7 +4,15 @@
       <div class="product-image">
         <app-button label="<" (buttonClicked)="onClickLeft()" class="image__button" />
         <div *ngIf="getCurrentImage() as currentImage">
-          <img [src]="currentImage.url" [alt]="currentImage.label" (click)="openImageInModal()" />
+          <img
+            [src]="currentImage.url"
+            [alt]="currentImage.label"
+            (click)="openImageInModal()"
+            role="button"
+            tabindex="0"
+            (keydown.enter)="openImageInModal()"
+            (keydown.space)="openImageInModal()"
+          />
           <app-modal
             [isModalOpen]="isModalOpen"
             [images]="productImages"

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.html
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.html
@@ -2,7 +2,9 @@
   @for (product of products; track product.id) {
     <div class="product__wrapper">
       <div class="product-image">
-        <app-button label="<" (buttonClicked)="onClickLeft()" class="image__button" />
+        <app-button (buttonClicked)="onClickLeft()" class="image__button">
+          <div class="arrow arrow__left"></div>
+        </app-button>
         <div *ngIf="getCurrentImage() as currentImage">
           <img
             [src]="currentImage.url"
@@ -22,18 +24,21 @@
             (closeModalWindow)="onCloseModal($event)"
           ></app-modal>
         </div>
-        <app-button label=">" (buttonClicked)="onClickRight()" class="image__button" />
+        <app-button (buttonClicked)="onClickRight()" class="image__button">
+          <div class="arrow arrow__right"></div>
+        </app-button>
       </div>
       <div class="product-information">
         <h2 class="product-title">{{ getProductName(product) }}</h2>
         <div class="product-price__container">
+          <p class="product-currency">{{ getProductCurrency(product) }}</p>
           <p [ngClass]="{ 'product-old-price': hasDiscount(product), 'product-price': !hasDiscount(product) }">
             {{ getProductPrice(product) }}
           </p>
           <ng-container *ngIf="hasDiscount(product)">
             <p class="product-discount">{{ getProductDiscount(product) }}</p>
+            <p class="product-discount-value">-{{ getDiscountValue() }}%</p>
           </ng-container>
-          <p class="product-currency">{{ getProductCurrency(product) }}</p>
         </div>
         <app-button label="Add to cart" (buttonClicked)="buttonClickedAddToCart.emit()" class="product__button" />
         <p class="product-description">{{ getProductDescription(product) }}</p>

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.html
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.html
@@ -37,7 +37,7 @@
           </p>
           <ng-container *ngIf="hasDiscount(product)">
             <p class="product-discount">{{ getProductDiscount(product) }}</p>
-            <p class="product-discount-value">-{{ getDiscountValue() }}%</p>
+            <p class="product-discount-value">{{ getDiscountValue(product) }} off</p>
           </ng-container>
         </div>
         <app-button label="Add to cart" (buttonClicked)="buttonClickedAddToCart.emit()" class="product__button" />

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.scss
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.scss
@@ -34,15 +34,27 @@
   }
 }
 
-.image__button{
-  background-color: $color-input-search;
+.image__button {
   cursor: pointer;
-  color: $color-primary;
-  font-weight: bold;
-  font-size: 3.6rem;
+}
+
+.arrow {
+  width: 24px;
+  height: 24px;
   @extend %transition;
-  &:hover{
-    background-color: $color-button-disable;
+  &__left {
+    background-image: url('../../../assets/icons/arrow_back.svg');
+
+    &:hover {
+      background-image: url('../../../assets/icons/arrow_back_hover.svg');
+    }
+  }
+  &__right {
+    background-image: url('../../../assets/icons/arrow_forward.svg');
+
+    &:hover {
+      background-image: url('../../../assets/icons/arrow_forward_hover.svg');
+    }
   }
 }
 
@@ -79,7 +91,7 @@
     font-size: 2.8rem;
   }
   @include media-tablet {
-    font-size: 2.0rem;
+    font-size: 2rem;
   }
 }
 
@@ -104,7 +116,7 @@
   font-size: 3rem;
   @include media-tablet {
     font-size: 2.2rem;
-  } 
+  }
 }
 
 .product-discount {

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.scss
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.scss
@@ -6,12 +6,15 @@
   display: flex;
   justify-content: space-evenly;
   padding: 7rem 3rem;
+
   @include media-laptop-tablet {
     column-gap: 2rem;
   }
+
   @include media-tablet {
     padding: 5rem;
   }
+
   @include media-mobile-big {
     flex-direction: column;
     padding: 3rem;
@@ -25,9 +28,11 @@
   text-align: center;
   align-items: center;
   display: flex;
+
   @include media-laptop-tablet {
     width: 50%;
   }
+
   @include media-mobile-big {
     width: 100%;
     text-align: center;
@@ -42,6 +47,7 @@
   width: 24px;
   height: 24px;
   @extend %transition;
+
   &__left {
     background-image: url('../../../assets/icons/arrow_back.svg');
 
@@ -62,9 +68,11 @@
   width: 100%;
   height: 70%;
   cursor: pointer;
+
   @include media-laptop-tablet {
     width: 90%;
   }
+
   @include media-mobile-big {
     width: 50%;
   }
@@ -75,10 +83,12 @@
   flex-direction: column;
   row-gap: 2.2rem;
   width: 50%;
+
   @include media-tablet {
     row-gap: 1.8rem;
     width: 60%;
   }
+
   @include media-mobile-big {
     width: 100%;
   }
@@ -87,9 +97,11 @@
 .product-title {
   color: $color-primary;
   font-size: 3.6rem;
+
   @include media-laptop-tablet {
     font-size: 2.8rem;
   }
+
   @include media-tablet {
     font-size: 2rem;
   }
@@ -106,6 +118,7 @@
   color: $color-old-price;
   text-decoration: line-through;
   font-size: 2rem;
+
   @include media-tablet {
     font-size: 1.8rem;
   }
@@ -114,6 +127,7 @@
   color: $color-old-price;
   font-weight: bold;
   font-size: 3rem;
+
   @include media-tablet {
     font-size: 2.2rem;
   }
@@ -123,8 +137,26 @@
   font-size: 3rem;
   font-weight: bold;
   color: $color-additional;
+
   @include media-tablet {
     font-size: 2.2rem;
+  }
+}
+
+.product-discount-value {
+  padding: 0.7rem 1rem;
+  border-radius: 2.5rem;
+  font-weight: bold;
+  background-color: $color-discount;
+
+  @include rwd-font16-size;
+
+  @include media-laptop-tablet {
+    padding: 0.6rem;
+  }
+
+  @include media-mobile-big {
+    padding: 0.5rem;
   }
 }
 
@@ -136,10 +168,12 @@
   align-self: baseline;
   cursor: pointer;
   @extend %transition;
+
   &:hover {
     background: $color-button-hover;
     box-shadow: 0 1px 3px $color-input-search;
   }
+
   @include media-mobile {
     font-weight: 400;
   }
@@ -149,10 +183,12 @@
   font-size: 1.8rem;
   line-height: 1.5;
   font-style: italic;
+
   @include media-laptop-tablet {
     font-size: 1.6rem;
     line-height: normal;
   }
+
   @include media-tablet {
     font-size: 1.4rem;
   }

--- a/src/app/features/product/product-detailed-info/product-detailed-info.component.ts
+++ b/src/app/features/product/product-detailed-info/product-detailed-info.component.ts
@@ -72,6 +72,17 @@ export class ProductDetailedInfoComponent implements OnInit {
     return isSale;
   }
 
+  public getDiscountValue(product: ProductDetailed): number {
+    if (product && this.hasDiscount(product)) {
+      const discountPrice = Number.parseFloat(this.getProductDiscount(product));
+      const regularPrice = Number.parseFloat(this.getProductPrice(product));
+
+      return Math.round((1 - discountPrice / regularPrice) * 100);
+    }
+
+    return 0;
+  }
+
   public getProductCurrency(product: ProductDetailed): string {
     const productCurrency = product.masterData.current.masterVariant.prices[0].value.currencyCode;
 


### PR DESCRIPTION
## Cudo-Shop

### [Sprint 3: Catalog Product Page, Detailed Product Page & User Profile Page Implementation](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%233.md)

#### 🟢 Bugfix/product details layout

1. Screenshot:
![image](https://github.com/user-attachments/assets/cba0db46-16f5-41af-bd5c-9f68a0d60e97)
![image](https://github.com/user-attachments/assets/ead349dd-bf45-4955-894d-c92737949587)

3. Done 07.06.2025 / deadline 09.06.2025

---

##### 📝 This is a ...

- [x] New feature

#####  Changed files:
- src/app/features/product/product-detailed-info/modal/modal/modal.component.html
- src/app/features/product/product-detailed-info/modal/modal/modal.component.scss
- src/app/features/product/product-detailed-info/product-detailed-info.component.html
- src/app/features/product/product-detailed-info/product-detailed-info.component.scss
- src/app/features/product/product-detailed-info/product-detailed-info.component.ts


##### ☑️ Self Check before Merge

⚠️ _Please check all items below before review_ ⚠️

- [x] - Add discount-value element to the product details info into the product-price__container element.
- [x] - Add material icons close to the large image preview modal close button from src/app/assets/icons/close_24dp.svg and for :hover from src/app/assets/icons/close_24dp_color.svg
- [x] - Add [material icons](https://fonts.google.com/icons?selected=Material+Symbols+Outlined:arrow_forward_ios:FILL@0;wght@400;GRAD@0;opsz@24&icon.query=arrow&icon.size=24&icon.color=%23000000) Arrow Forward iOS and Arrow Back iOS for navigation of the image slider