### PR TITLE
Feat/3 08/category breadcrumb navigation

### DIFF
--- a/src/app/features/main-page/main-page.component.html
+++ b/src/app/features/main-page/main-page.component.html
@@ -11,6 +11,6 @@
 
 <main class="main">
   <app-breadcrumb></app-breadcrumb>
-  <router-outlet [routerOutletData]="{ books: books(), cosmetics: cosmetics() }" />
+  <router-outlet />
 </main>
 <app-footer />

--- a/src/app/features/main-page/main-page.component.html
+++ b/src/app/features/main-page/main-page.component.html
@@ -10,6 +10,7 @@
 />
 
 <main class="main">
+  <app-breadcrumb></app-breadcrumb>
   <router-outlet [routerOutletData]="{ books: books(), cosmetics: cosmetics() }" />
 </main>
 <app-footer />

--- a/src/app/features/main-page/main-page.component.ts
+++ b/src/app/features/main-page/main-page.component.ts
@@ -1,7 +1,5 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
-import { Book } from '../../shared/interfaces/book';
-import { Cosmetics } from '../../shared/interfaces/cosmetics';
 import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { NavigateToSpecificRouteService } from '../../shared/services/navigate-to-specific-route/navigate-to-specific-route.service';
@@ -47,34 +45,4 @@ export class MainPageComponent implements OnInit {
   public goToCart(): void {
     this.navigateToRoute('/cart');
   }
-
-  public books = signal<Book[]>([
-    {
-      id: 1,
-      title: 'School',
-    },
-    {
-      id: 2,
-      title: 'Home',
-    },
-    {
-      id: 3,
-      title: 'Work',
-    },
-  ]);
-
-  public cosmetics = signal<Cosmetics[]>([
-    {
-      id: 1,
-      title: 'Hair care',
-    },
-    {
-      id: 2,
-      title: 'Skincare',
-    },
-    {
-      id: 3,
-      title: 'Perfume',
-    },
-  ]);
 }

--- a/src/app/features/main-page/main-page.component.ts
+++ b/src/app/features/main-page/main-page.component.ts
@@ -6,10 +6,11 @@ import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { NavigateToSpecificRouteService } from '../../shared/services/navigate-to-specific-route/navigate-to-specific-route.service';
 import { AuthService } from '../../core/auth/auth.service';
+import { BreadcrumbComponent } from '../product/components/breadcrumb/breadcrumb.component';
 
 @Component({
   selector: 'app-main-page',
-  imports: [HeaderComponent, FooterComponent, RouterOutlet],
+  imports: [HeaderComponent, FooterComponent, RouterOutlet, BreadcrumbComponent],
   templateUrl: './main-page.component.html',
   styleUrl: './main-page.component.scss',
 })

--- a/src/app/features/main-page/main-page.routes.ts
+++ b/src/app/features/main-page/main-page.routes.ts
@@ -11,10 +11,12 @@ export const mainRoutes: Routes = [
     path: '',
     title: 'Cudo Shop',
     component: MainPageComponent,
+    data: { breadcrumb: 'Cudo-Shop' },
     children: [
       {
         path: 'main',
         component: HomeComponent,
+        data: { breadcrumb: '' },
       },
       {
         path: 'registration',
@@ -29,10 +31,12 @@ export const mainRoutes: Routes = [
       {
         path: 'books',
         loadChildren: () => import('../product/product.routes').then((c) => c.productRoutes),
+        data: { breadcrumb: 'Books' },
       },
       {
         path: 'cosmetics',
         loadChildren: () => import('../product/product.routes').then((c) => c.productRoutes),
+        data: { breadcrumb: 'Cosmetics' },
       },
       {
         path: 'profile',

--- a/src/app/features/main-page/main-page.routes.ts
+++ b/src/app/features/main-page/main-page.routes.ts
@@ -11,12 +11,11 @@ export const mainRoutes: Routes = [
     path: '',
     title: 'Cudo Shop',
     component: MainPageComponent,
-    data: { breadcrumb: 'Cudo-Shop' },
+    data: { breadcrumb: 'Home' },
     children: [
       {
         path: 'main',
         component: HomeComponent,
-        data: { breadcrumb: '' },
       },
       {
         path: 'registration',

--- a/src/app/features/product/components/breadcrumb/breadcrumb.component.html
+++ b/src/app/features/product/components/breadcrumb/breadcrumb.component.html
@@ -1,0 +1,11 @@
+<div class="nav__wrapper">
+  <nav aria-label="breadcrumb" class="header__nav">
+    <div class="header__nav__icon__books"></div>
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item" *ngFor="let breadcrumb of breadcrumbs$ | async">
+        <a [routerLink]="breadcrumb.url">{{ breadcrumb.label }}</a
+        ><span>/</span>
+      </li>
+    </ol>
+  </nav>
+</div>

--- a/src/app/features/product/components/breadcrumb/breadcrumb.component.html
+++ b/src/app/features/product/components/breadcrumb/breadcrumb.component.html
@@ -3,8 +3,8 @@
     <div class="header__nav__icon__books"></div>
     <ol class="breadcrumb">
       <li class="breadcrumb-item" *ngFor="let breadcrumb of breadcrumbs$ | async">
-        <a [routerLink]="breadcrumb.url">{{ breadcrumb.label }}</a
-        ><span>/</span>
+        <span>/</span>
+        <a [routerLink]="breadcrumb.url">{{ breadcrumb.label }}</a>
       </li>
     </ol>
   </nav>

--- a/src/app/features/product/components/breadcrumb/breadcrumb.component.scss
+++ b/src/app/features/product/components/breadcrumb/breadcrumb.component.scss
@@ -1,0 +1,49 @@
+@use '../../../../../style/abstract/constant' as *;
+@use '../../../../../style/abstract/placeholders' as *;
+@use '../../../../../style/abstract/mixins' as *;
+
+.nav__wrapper {
+  display: flex;
+  padding: 2rem 3rem 0;
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+.header__nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+
+  .breadcrumb {
+    display: flex;
+    align-items: center;
+    color: #999999;
+    font-size: 1.5rem;
+    list-style-type: none;
+
+    a {
+      color: #b7b7b7;
+      font-size: 1.5rem;
+      text-decoration: none;
+
+      &:hover {
+        color: $color-additional;
+      }
+    }
+
+    span {
+      margin: 0 1rem;
+    }
+  }
+
+  &__icon {
+    &__books {
+      width: 24px;
+      height: 24px;
+      background-image: url('../../../../assets/icons/menu_book_24dp.svg');
+      background-repeat: no-repeat;
+      background-position: center;
+      position: relative;
+    }
+  }
+}

--- a/src/app/features/product/components/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/features/product/components/breadcrumb/breadcrumb.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BreadcrumbComponent } from './breadcrumb.component';
+
+describe('BreadcrumbComponent', () => {
+  let component: BreadcrumbComponent;
+  let fixture: ComponentFixture<BreadcrumbComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BreadcrumbComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BreadcrumbComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/product/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/features/product/components/breadcrumb/breadcrumb.component.ts
@@ -1,13 +1,13 @@
 import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { AsyncPipe, NgForOf, NgIf } from '@angular/common';
+import { AsyncPipe, NgForOf } from '@angular/common';
 import { BreadcrumbService } from './breadcrumb.service';
 import { Observable } from 'rxjs';
 import { Breadcrumb } from './breadcrumb.model';
 
 @Component({
   selector: 'app-breadcrumb',
-  imports: [RouterLink, NgForOf, NgIf, AsyncPipe],
+  imports: [RouterLink, NgForOf, AsyncPipe],
   templateUrl: './breadcrumb.component.html',
   styleUrl: './breadcrumb.component.scss',
 })

--- a/src/app/features/product/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/features/product/components/breadcrumb/breadcrumb.component.ts
@@ -1,0 +1,19 @@
+import { Component, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { AsyncPipe, NgForOf, NgIf } from '@angular/common';
+import { BreadcrumbService } from './breadcrumb.service';
+import { Observable } from 'rxjs';
+import { Breadcrumb } from './breadcrumb.model';
+
+@Component({
+  selector: 'app-breadcrumb',
+  imports: [RouterLink, NgForOf, NgIf, AsyncPipe],
+  templateUrl: './breadcrumb.component.html',
+  styleUrl: './breadcrumb.component.scss',
+})
+export class BreadcrumbComponent {
+  private breadcrumbService: BreadcrumbService = inject(BreadcrumbService);
+  public breadcrumbs$: Observable<Breadcrumb[]> = this.breadcrumbService.breadcrumbs$;
+
+  constructor() {}
+}

--- a/src/app/features/product/components/breadcrumb/breadcrumb.model.ts
+++ b/src/app/features/product/components/breadcrumb/breadcrumb.model.ts
@@ -1,0 +1,4 @@
+export interface Breadcrumb {
+  label: string;
+  url: string;
+}

--- a/src/app/features/product/components/breadcrumb/breadcrumb.service.ts
+++ b/src/app/features/product/components/breadcrumb/breadcrumb.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, filter } from 'rxjs';
+import { ActivatedRouteSnapshot, NavigationEnd, Router } from '@angular/router';
+import { Breadcrumb } from './breadcrumb.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BreadcrumbService {
+  private readonly _breadcrumbs$ = new BehaviorSubject<Breadcrumb[]>([]);
+  public readonly breadcrumbs$ = this._breadcrumbs$.asObservable();
+
+  constructor(private router: Router) {
+    this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
+      const root = this.router.routerState.snapshot.root;
+      const breadcrumbs: Breadcrumb[] = [];
+      this.addBreadcrumb(root, [], breadcrumbs);
+      this._breadcrumbs$.next(breadcrumbs);
+    });
+  }
+
+  private addBreadcrumb(route: ActivatedRouteSnapshot, parentUrl: string[], breadcrumbs: Breadcrumb[]) {
+    if (route) {
+      const routeUrl = parentUrl.concat(route.url.map((url) => url.path));
+
+      if (route.data['breadcrumb']) {
+        const breadcrumb = {
+          label: route.data['breadcrumb'],
+          url: '/' + routeUrl.join('/'),
+        };
+        breadcrumbs.push(breadcrumb);
+      }
+
+      if (route.firstChild) {
+        this.addBreadcrumb(route.firstChild, routeUrl, breadcrumbs);
+      }
+    }
+  }
+}

--- a/src/app/features/product/components/breadcrumb/breadcrumb.service.ts
+++ b/src/app/features/product/components/breadcrumb/breadcrumb.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal, WritableSignal } from '@angular/core';
 import { BehaviorSubject, filter } from 'rxjs';
 import { ActivatedRouteSnapshot, NavigationEnd, Router } from '@angular/router';
 import { Breadcrumb } from './breadcrumb.model';
@@ -10,12 +10,15 @@ export class BreadcrumbService {
   private readonly _breadcrumbs$ = new BehaviorSubject<Breadcrumb[]>([]);
   public readonly breadcrumbs$ = this._breadcrumbs$.asObservable();
 
+  public selectedCategoryName: WritableSignal<string> = signal<string>('');
+
   constructor(private router: Router) {
     this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
       const root = this.router.routerState.snapshot.root;
       const breadcrumbs: Breadcrumb[] = [];
       this.addBreadcrumb(root, [], breadcrumbs);
       this._breadcrumbs$.next(breadcrumbs);
+      this.selectedCategoryName.set('');
     });
   }
 
@@ -35,5 +38,47 @@ export class BreadcrumbService {
         this.addBreadcrumb(route.firstChild, routeUrl, breadcrumbs);
       }
     }
+  }
+
+  public setLastBreadcrumb(category: string): void {
+    this._breadcrumbs$.value.push({ label: category, url: '/' });
+  }
+
+  public removeLastBreadcrumb(): void {
+    this._breadcrumbs$.value.pop();
+  }
+
+  public resetCurrentCategory() {
+    if (this.selectedCategoryName() !== '' && this.selectedCategoryName() === this.getLast()?.label) {
+      this.removeLastBreadcrumb();
+      this.selectedCategoryName.set('');
+    }
+  }
+
+  public setCategory(category: string): void {
+    if (category === this.selectedCategoryName()) {
+      return;
+    }
+
+    if (this.selectedCategoryName() === '') {
+      this.setLastBreadcrumb(category);
+    } else if (this.selectedCategoryName() === this.getLast()?.label) {
+      //if category already shown, just replace with new one
+      this.removeLastBreadcrumb();
+      this.setLastBreadcrumb(category);
+    } else {
+      //do nothing
+    }
+
+    this.selectedCategoryName.set(category);
+  }
+
+  private getLast(): Breadcrumb | null {
+    const array: Breadcrumb[] = this._breadcrumbs$.value;
+    if (array.length > 0) {
+      return array[array.length - 1];
+    }
+
+    return null;
   }
 }

--- a/src/app/features/product/product-list/product-list.component.html
+++ b/src/app/features/product/product-list/product-list.component.html
@@ -9,7 +9,7 @@
             @for (category of categories; track $index) {
               <li
                 tabindex="0"
-                (click)="filterByCategory(category.id)"
+                (click)="setCurrentCategory(category)"
                 (keyup)="onKeyUpFilter($event, category.id)"
                 [ngClass]="{ selected: selectedCategory === category.id }"
               >
@@ -59,7 +59,7 @@
             @for (category of categories; track $index) {
               <li
                 tabindex="0"
-                (click)="filterByCategory(category.id)"
+                (click)="setCurrentCategory(category)"
                 (keyup)="onKeyUpFilter($event, category.id)"
                 [ngClass]="{ selected: selectedCategory === category.id }"
               >

--- a/src/app/features/product/product-list/product-list.component.html
+++ b/src/app/features/product/product-list/product-list.component.html
@@ -1,15 +1,6 @@
 <div class="wrapper">
   <div class="product-list__wrapper">
     @if (currentRoute === '/main') {
-      <!--      <div class="product-page__header">-->
-      <!--        <div class="product-page__header__icon-books"></div>-->
-      <!--        <a routerLink="/">-->
-      <!--          <h4>CUDO-SHOP</h4>-->
-      <!--        </a>-->
-      <!--        <span>/</span>-->
-      <!--        <h5>books</h5>-->
-      <!--      </div>-->
-
       <div class="product-list__container">
         <aside class="categories">
           <h2>Filters</h2>
@@ -60,15 +51,6 @@
     }
 
     @if (currentRoute === '/books') {
-      <div class="product-page__header">
-        <div class="product-page__header__icon-books"></div>
-        <a routerLink="/">
-          <h4>CUDO-SHOP</h4>
-        </a>
-        <span>/</span>
-        <h5>books</h5>
-      </div>
-
       <div class="product-list__container">
         <aside class="categories">
           <h2>Filters</h2>
@@ -119,15 +101,6 @@
     }
 
     @if (currentRoute === '/cosmetics') {
-      <div class="product-page__header">
-        <div class="product-page__header__icon-cosmetics"></div>
-        <a routerLink="/">
-          <h4>CUDO-SHOP</h4>
-        </a>
-        <span>/</span>
-        <h5>cosmetics</h5>
-      </div>
-
       <div class="product-list__container">
         <aside class="categories">
           <h2>Filters</h2>

--- a/src/app/features/product/product-list/product-list.component.scss
+++ b/src/app/features/product/product-list/product-list.component.scss
@@ -52,42 +52,6 @@
   }
 }
 
-.product-page__header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: #999999;
-  font-size: 1.5rem;
-
-  a {
-    text-decoration: none;
-    color: #b7b7b7;
-    font-size: 1.5rem;
-
-    &:hover {
-      color: $color-additional;
-    }
-  }
-
-  &__icon-books {
-    width: 24px;
-    height: 24px;
-    background-image: url('../../../assets/icons/menu_book_24dp.svg');
-    background-repeat: no-repeat;
-    background-position: center;
-    position: relative;
-  }
-
-  &__icon-cosmetics {
-    width: 24px;
-    height: 24px;
-    background-image: url('../../../assets/icons/spa_24dp.svg');
-    background-repeat: no-repeat;
-    background-position: center;
-    position: relative;
-  }
-}
-
 aside {
   padding: 2rem;
   width: 29rem;

--- a/src/app/features/product/product-list/product-list.component.ts
+++ b/src/app/features/product/product-list/product-list.component.ts
@@ -16,7 +16,8 @@ import { BriefCardComponent } from '../components/brief-card/brief-card.componen
 import { ProductButtonComponent } from '../components/product-button/product-button.component';
 import { SortByPriceComponent } from '../components/sort-by-price/sort-by-price.component';
 import { SortByAlphabeticalComponent } from '../components/sort-by-alphabetical/sort-by-alphabetical.component';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BreadcrumbService } from '../components/breadcrumb/breadcrumb.service';
 
 @Component({
   selector: 'app-product-list',
@@ -28,6 +29,7 @@ import { ReactiveFormsModule } from '@angular/forms';
     SortByPriceComponent,
     SortByAlphabeticalComponent,
     ReactiveFormsModule,
+    FormsModule,
   ],
   templateUrl: './product-list.component.html',
   styleUrl: './product-list.component.scss',
@@ -48,6 +50,7 @@ export class ProductListComponent implements OnInit {
 
     public productProjectionsHelperService: ProductProjectionsHelperService,
     public categoryHelperService: CategoryHelperService,
+    private breadcrumbService: BreadcrumbService,
   ) {}
 
   public ngOnInit() {
@@ -65,6 +68,7 @@ export class ProductListComponent implements OnInit {
 
   public resetFilters(): void {
     this.selectedCategory = '';
+    this.breadcrumbService.resetCurrentCategory();
   }
 
   public loadProducts() {
@@ -85,6 +89,11 @@ export class ProductListComponent implements OnInit {
         this.handleError(error);
       },
     });
+  }
+
+  public setCurrentCategory(category: Category) {
+    this.breadcrumbService.setCategory(category.name['en-US']);
+    this.filterByCategory(category.id);
   }
 
   public onKeyUpFilter(event: KeyboardEvent, categoryId: string): void {

--- a/src/app/features/product/product.routes.ts
+++ b/src/app/features/product/product.routes.ts
@@ -6,9 +6,11 @@ export const productRoutes: Routes = [
   {
     path: '',
     component: ProductListComponent,
+    data: { breadcrumb: '' },
   },
   {
     path: ':key',
     component: ProductDetailedInfoComponent,
+    data: { breadcrumb: 'Product Details' },
   },
 ];


### PR DESCRIPTION
## Cudo-Shop

### [Sprint 3 - Catalog Product, Detailed Product, and User Profile Pages Implementation](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%233.md) 📚🔍👥

#### 🟢 Category Navigation (+ 25 / 25 points) 🧭

1. Screenshot:
<img width="600" alt="edit mode screenshot image" src="https://firebasestorage.googleapis.com/v0/b/personal-portfolio-b7e69.appspot.com/o/RS-School-JavaScript-course-2024%2FFinal-task%2FBreadcrumb.png?alt=media&token=eae8130c-87b7-44cc-b707-752fb9af5f56" />

2. Done 07.06.2025 / deadline 09.06.2025

---

##### 📝 This is a ...

- [x] New feature

##### 🔗 Related issue link

- [x] (+ 25 / 25 points) Implement easy-to-use and clear navigation options for users to explore and switch between different product categories or subcategories using the commercetools API. [RSS-ECOMM-3_08](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint3/RSS-ECOMM-3_08.md) 🗺️

##### ☑️ Self Check before Merge

⚠️ _Please check all items below before review_ ⚠️

- [x] - User-friendly navigation for product categories and subcategories is implemented and clearly visible 🔍.
- [x] - Users can switch between different product categories and subcategories.
- [x] - Clicking on a category or subcategory updates the product list accordingly 🔄.
- [x] - Breadcrumb navigation or a similar navigational aid is present on all category pages, accurately reflecting the category hierarchy and the user's current location within it.
- [x] - Clicking on a segment of the breadcrumb navigation takes the user to the corresponding category or subcategory page.