### PR TITLE
Feat/4-22/Add Routing for About Us Page.

### DIFF
--- a/src/app/features/about-us/about-us.component.html
+++ b/src/app/features/about-us/about-us.component.html
@@ -1,0 +1,6 @@
+<div class="wrapper">
+  <div class="content-wrapper">
+    <p>about-us works!</p>
+    <p>This page should display information about the team and the project.</p>
+  </div>
+</div>

--- a/src/app/features/about-us/about-us.component.scss
+++ b/src/app/features/about-us/about-us.component.scss
@@ -1,0 +1,19 @@
+@use '../../../style/abstract/constant' as *;
+@use '../../../style/abstract/placeholders' as *;
+@use '../../../style/abstract/mixins' as *;
+
+.content-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  padding: 2rem 1.5rem;
+  min-height: calc(100vh - 124px);
+
+  @include media-laptop-tablet {
+    column-gap: 1.5rem;
+  }
+
+  @include media-mobile-big {
+    flex-direction: column;
+  }
+}

--- a/src/app/features/about-us/about-us.component.spec.ts
+++ b/src/app/features/about-us/about-us.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AboutUsComponent } from './about-us.component';
+
+describe('AboutUsComponent', () => {
+  let component: AboutUsComponent;
+  let fixture: ComponentFixture<AboutUsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AboutUsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AboutUsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/about-us/about-us.component.ts
+++ b/src/app/features/about-us/about-us.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-about-us',
+  imports: [],
+  templateUrl: './about-us.component.html',
+  styleUrl: './about-us.component.scss',
+})
+export class AboutUsComponent {}

--- a/src/app/features/main-page/main-page.routes.ts
+++ b/src/app/features/main-page/main-page.routes.ts
@@ -5,6 +5,7 @@ import { RegistrationComponent } from '../auth/registration/registration.compone
 import { LoginComponent } from '../auth/login/login.component';
 import { authGuard } from '../../core/auth/auth.guard';
 import { isLoggedGuard } from '../../core/auth/is-logged.guard';
+import { AboutUsComponent } from '../about-us/about-us.component';
 
 export const mainRoutes: Routes = [
   {
@@ -16,6 +17,11 @@ export const mainRoutes: Routes = [
       {
         path: 'main',
         component: HomeComponent,
+      },
+      {
+        path: 'about-us',
+        component: AboutUsComponent,
+        data: { breadcrumb: 'About Us' },
       },
       {
         path: 'registration',

--- a/src/app/features/product/product-list/product-list.component.scss
+++ b/src/app/features/product/product-list/product-list.component.scss
@@ -27,9 +27,10 @@
 
 .product-list__wrapper {
   display: flex;
-  column-gap: 3rem;
+  flex-direction: column;
+  gap: 3rem;
   padding: 2rem 1.5rem;
-  min-height: calc(100vh - 80px);
+  min-height: calc(100vh - 124px);
 
   @include media-laptop-tablet {
     column-gap: 1.5rem;


### PR DESCRIPTION
## Cudo-Shop

### [Sprint 4 - Detailed Product Page Enhancement, Basket Page, Catalog Page Enhancement, and About Us Page Implementation](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%234.md) 🛍️📊🙋‍♂️🙋‍♀️

#### 🟢 Routing Implementation (+10 / 20 points) 🗺🔀

1. Done 10.06.2025 / deadline 23.06.2025

---

##### 📝 This is a ...

- [x] New feature

##### 🔗 Related issue link

- [x] (+10 / 10 points) 🎯 Implement routing for seamless navigation 🚀 to the About Us page 🤝 from all other pages, ensuring that the About Us page is accessible whether the user is logged in or not 🔒 and supports browser navigation buttons ⏩. [RSS-ECOMM-4_22](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint4/RSS-ECOMM-4_22.md)

##### ☑️ Self Check before Merge

⚠️ _Please check all items below before review_ ⚠️

- [x] Clicking on a navigation element directing to the About Us page takes the user to the About Us page 👥.
- [x] Navigating to the About Us page changes the URL in the browser 🌐.
- [x] The About Us page has a unique URL that can be directly accessed 🚏.
- [x] Directly accessing the About Us page's unique URL leads to the About Us page 👥.
- [x] The browser's back and forward buttons work as expected, enabling the user to navigate through their history of visited pages ⏪⏩.
- [x] The About Us page is accessible regardless of the user's authentication state 👥.